### PR TITLE
Use anchors for tab navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,23 @@
 // Tabs & Theme
 document.getElementById('themeToggle').addEventListener('click', ()=>document.documentElement.classList.toggle('light'));
-document.querySelectorAll('.tab-button').forEach(btn=>{
-  btn.addEventListener('click', ()=>{
-    document.querySelectorAll('.tab-button').forEach(b=>b.classList.remove('active'));
-    document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
-    btn.classList.add('active'); document.getElementById(btn.dataset.tab).classList.add('active');
+function activateTab(id){
+  document.querySelectorAll('.tab-button').forEach(b=>b.classList.remove('active'));
+  document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
+  document.querySelector(`.tab-button[data-tab="${id}"]`)?.classList.add('active');
+  document.getElementById(id)?.classList.add('active');
+}
+document.querySelectorAll('.tab-button').forEach(a=>{
+  a.addEventListener('click', e=>{
+    e.preventDefault();
+    const id = a.dataset.tab;
+    activateTab(id);
+    history.replaceState(null,'','#'+id);
   });
 });
+if(location.hash){
+  const id=location.hash.slice(1);
+  if(document.querySelector(`.tab-button[data-tab="${id}"]`)) activateTab(id);
+}
 navigator.serviceWorker?.addEventListener('message', e => {
   if (e.data?.type === 'SW_READY') document.body.classList.remove('updating');
 });

--- a/index.html
+++ b/index.html
@@ -16,20 +16,20 @@
   <h1>🎸 Chitarra Coach <span class="badge">Pro+ PWA</span></h1>
   <p class="subtitle">Percorso fino all’intermedio — lezioni, tracker, brani, fingerpicking, PWA & backup</p>
   <nav>
-    <button class="tab-button" data-tab="curriculum">Percorso</button>
-    <button class="tab-button active" data-tab="lessons">Lezioni</button>
-    <button class="tab-button" data-tab="practice">Progressi</button>
-    <button class="tab-button" data-tab="songs">Brani</button>
-    <button class="tab-button" data-tab="fingerpicking">Fingerpicking</button>
-    <button class="tab-button" data-tab="tuner">Accordatore</button>
-    <button class="tab-button" data-tab="metronome">Metronomo</button>
-    <button class="tab-button" data-tab="chords">Accordi</button>
-    <button class="tab-button" data-tab="progressions">Progressioni</button>
-    <button class="tab-button" data-tab="scales">Scale & Box</button>
-    <button class="tab-button" data-tab="ear">Ear</button>
-    <button class="tab-button" data-tab="exercises">Esercizi</button>
-    <button class="tab-button" data-tab="resources">Risorse</button>
-    <button class="tab-button" data-tab="settings">Impostazioni</button>
+    <a class="tab-button" href="#curriculum" data-tab="curriculum">Percorso</a>
+    <a class="tab-button active" href="#lessons" data-tab="lessons">Lezioni</a>
+    <a class="tab-button" href="#practice" data-tab="practice">Progressi</a>
+    <a class="tab-button" href="#songs" data-tab="songs">Brani</a>
+    <a class="tab-button" href="#fingerpicking" data-tab="fingerpicking">Fingerpicking</a>
+    <a class="tab-button" href="#tuner" data-tab="tuner">Accordatore</a>
+    <a class="tab-button" href="#metronome" data-tab="metronome">Metronomo</a>
+    <a class="tab-button" href="#chords" data-tab="chords">Accordi</a>
+    <a class="tab-button" href="#progressions" data-tab="progressions">Progressioni</a>
+    <a class="tab-button" href="#scales" data-tab="scales">Scale & Box</a>
+    <a class="tab-button" href="#ear" data-tab="ear">Ear</a>
+    <a class="tab-button" href="#exercises" data-tab="exercises">Esercizi</a>
+    <a class="tab-button" href="#resources" data-tab="resources">Risorse</a>
+    <a class="tab-button" href="#settings" data-tab="settings">Impostazioni</a>
     <button id="themeToggle" aria-label="Tema">🌓</button>
   </nav>
 </header>

--- a/style.css
+++ b/style.css
@@ -6,11 +6,11 @@ header{padding:24px 16px 8px;border-bottom:1px solid #242a4f}
 h1{margin:0;font-weight:800;letter-spacing:0.5px}.badge{font-size:.7em;background:#203063;border:1px solid #2d3b77;padding:3px 6px;border-radius:8px;margin-left:6px}
 .subtitle{color:var(--muted);margin:6px 0 12px}
 nav{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
-.tab-button{background:#1c2250;color:var(--ink);border:1px solid #2a3170;padding:8px 12px;border-radius:10px;cursor:pointer}
+.tab-button{background:#1c2250;color:var(--ink);border:1px solid #2a3170;padding:8px 12px;border-radius:10px;cursor:pointer;text-decoration:none}
 .tab-button.active{border-color:var(--accent);box-shadow:0 0 0 2px #7aa2ff33}
 #themeToggle{margin-left:auto;background:#1c2250;border:1px solid #2a3170;border-radius:10px;padding:8px 10px;color:var(--ink);cursor:pointer}
 main{padding:16px;max-width:1200px;margin:0 auto}
-.tab{display:none}.tab.active{display:block}
+.tab{display:none}.tab.active,.tab:target{display:block}
 .card{background:var(--card);border:1px solid #242a4f;border-radius:16px;padding:16px;margin-top:12px}
 .row{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
 .grid.two{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}


### PR DESCRIPTION
## Summary
- Replace tab navigation buttons with anchor links retaining `data-tab`
- Intercept anchor clicks in `app.js` to activate tabs and update history
- Allow CSS `:target` to reveal sections and style anchors like buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a369a4818832784d0931e0b56f43c